### PR TITLE
changed critical fact sheet url

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,7 +424,7 @@
                 <h1 class="text-uppercase margin-top-50 uconn-blue">Strengthening Connecticut</h1>
                 <p class="margin-top-25">The majority of recent UConn grads from Connecticut — <strong>76%</strong> — are living and working in the state, while <strong>27%</strong> of recent graduates from out of state who are employed work here.</p>
                 <p class="margin-top-25">In total, <strong>138,174</strong> UConn alumni work in the state of Connecticut.</p>
-                <a href="https://uconn.edu/content/uploads/2018/11/UConn-Critical-Fact-Sheet-102918.pdf" class="btn btn-danger text-uppercase margin-bottom-50">
+                <a href="https://uconn.edu/critical-fact-sheet" class="btn btn-danger text-uppercase margin-bottom-50">
                     <strong>CT Impact Fact Sheet</strong>
                 </a>
             </div>


### PR DESCRIPTION
I made a `/critical-fact-sheet` route on uconn.edu that can be mapped to new fact sheets as they are made. this way other sites won't have to be updated as often.